### PR TITLE
Accept application/json without charset

### DIFF
--- a/src/main/scala/com/twitter/diffy/lifter/HttpLifter.scala
+++ b/src/main/scala/com/twitter/diffy/lifter/HttpLifter.scala
@@ -63,7 +63,7 @@ class HttpLifter(excludeHttpHeadersComparison: Boolean) {
           )
 
         /** When Content-Type is set as application/json, lift as Json **/
-        case (Some(mediaType), _) if mediaType.is(MediaType.JSON_UTF_8) => {
+        case (Some(mediaType), _) if mediaType.is(MediaType.JSON_UTF_8) || mediaType.toString == "application/json" => {
           val jsonContentTry = Try {
             JsonLifter.decode(r.getContent.toString(Charsets.Utf8))
           }


### PR DESCRIPTION
While testing diffy against a JSON service API, I found out that the JSON lifting is only triggered for `application/json; charset="UTF-8"` content type. 

I used the same trick used for HTML lifting a few lines below and accept plain `application/json` content type.