### PR TITLE
Adding docker-compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ start using Diffy to compare three instances of your service:
     curl localhost:31900/your/application/route?with=queryparams
     ```
 
+### Running example on docker-compose
+
+Inside the example directory you will find instructions to run a complete example with apis and diffy configured and ready to run using docker-compose.
+
+
 7. Watch the differences show up in your browser at [http://localhost:31149](http://localhost:31149).
  
 ## FAQ's

--- a/README.md
+++ b/README.md
@@ -80,12 +80,11 @@ start using Diffy to compare three instances of your service:
     curl localhost:31900/your/application/route?with=queryparams
     ```
 
+7. Watch the differences show up in your browser at [http://localhost:31149](http://localhost:31149).
+
 ### Running example on docker-compose
 
 Inside the example directory you will find instructions to run a complete example with apis and diffy configured and ready to run using docker-compose.
-
-
-7. Watch the differences show up in your browser at [http://localhost:31149](http://localhost:31149).
  
 ## FAQ's
    For safety reasons `POST`, `PUT`, ` DELETE ` are ignored by default . Add ` -allowHttpSideEffects=true ` to your command line arguments to enable these verbs.

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,60 @@
+This is an example of diffy. 
+
+## Running
+
+To run it you will need docker and docker-compose installed. Read more about it here: https://www.docker.com/toolbox
+
+In this directory, run docker compose up command:
+
+      $ docker-compose up
+
+It will download the needed images and start the application. You will notice that the logs for all the four services: the twitter diffy proxy, the candidate service, the primary and secondary services. 
+You will be able to access the web console for diffy on http://localhost:8888/
+
+Now you can curl to check the differences:
+
+      $ curl http://localhost:31900/endpoint
+
+In the web console you will be able to see the diffs. 
+
+To change the services the only thing you need to do is to change the three flavor files withing the flavors directory, candidate, primary and secondary. Whatever you change there will change when you restart the docker-compose.
+
+ps: If you are running on mac or windows, remember to use the docker-machine/boot2docker/whereveryourundockeron ip instead of localhost, or do port forward it to localhost.
+
+Have fun!
+
+## Digging a bit more
+
+There are some other resources running in the same containers. You can play with it with the following curls:
+
+      $ curl --header "Canonical-Resource: /endpoint" http://localhost:31900/endpoint
+      $ curl --header "Canonical-Resource: /endpoint/foo" http://localhost:31900/endpoint/foo
+      $ curl --header "Canonical-Resource: /endpoint/meh" http://localhst:31900/endpoint/meh
+
+## Applying to your own service
+
+As you can see in the docker-compose.yml, you can replace the container with two different versions of your service and expose the ports in a way to keep the same configuratio in both services. For example:
+
+      candidate:
+        image: mycompany/my_service:new_version
+        ports:
+          - "8080"
+      
+      primary:
+        image: mycompany/my_service:stable_version
+        ports:
+          - "8080"
+      
+      secondary:
+        image: mycompany/my_service:stable_version
+        ports:
+          - "8080"
+
+Than run docker-compose up again.
+
+## What is the service being tested here?
+
+It is a rest-shifter service. Easy way to create simple service mocks and prototypes. 
+Read more: https://github.com/camiloribeiro/restshifter
+
+This example was originaly posted on https://github.com/camiloribeiro/dockdiffy under the Apache License, Version 2.0 (the "License").

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -1,0 +1,34 @@
+diffy:
+  image: camiloribeiro/twitter-diffy
+  ports:
+    - "8888:8888"
+    - "31900:31900"
+  links:
+    - primary 
+    - secondary
+    - candidate
+  command: java -jar ./target/scala-2.11/diffy-server.jar -candidate='candidate:8080' -master.primary='primary:8080' -master.secondary='secondary:8080' -service.protocol='http' -serviceName='Happy Service' -proxy.port=:31900 -admin.port=:8881 -http.port=:8888 -rootUrl='localhost:8888'
+
+candidate:
+  image: camiloribeiro/rest_shifter
+  ports:
+    - "9881:8080"
+  volumes:
+    - flavors/candidate:/root/.rest_shifter/flavors
+  command: -s
+
+primary:
+  image: camiloribeiro/rest_shifter
+  ports:
+    - "9882:8080"
+  volumes:
+    - flavors/primary:/root/.rest_shifter/flavors
+  command: -s
+
+secondary:
+  image: camiloribeiro/rest_shifter
+  ports:
+    - "9883:8080"
+  volumes:
+    - flavors/secondary:/root/.rest_shifter/flavors
+  command: -s

--- a/example/flavors/candidate/endpointcandidate.flavor
+++ b/example/flavors/candidate/endpointcandidate.flavor
@@ -1,0 +1,10 @@
+## ! ~/.rest_shifter/flavors/hello_world.flavor
+method_used                 = "get"
+path                        = "/endpoint"
+request_accept              = ""
+request_content_type        = ""
+response_sleep              = 0
+response_status             = "200"
+response_body               = { "sizes": { "ipad": { "h": 313, "w": 621, "url": "https://pbs.twimg.com/profile_banners/6253282/1347394302/ipad" }, "ipad_retina": { "h": 626, "w": 1252, "url": "https://pbs.twimg.com/profile_banners/6253282/1347394302/ipad_retina" }, "web": { "h": 260, "w": 520, "url": "https://pbs.twimg.com/profile_banners/6253282/1347394302/web" }, "web_retina": { "h": 520, "w": 1040, "url": "https://pbs.twimg.com/profile_banners/6253282/1347394302/web_retina" }, "mobile": { "h": 160, "w": 320, "url": "https://pbs.twimg.com/profile_banners/6253282/1347394302/mobile" }, "mobile_retina": { "h": 320, "w": 640, "url": "https://pbs.twimg.com/profile_banners/6253282/1347394302/mobile_retina" }, "300x100": { "h": 100, "w": 300, "url": "https://pbs.twimg.com/profile_banners/6253282/1347394302/300x100" }, "600x200": { "h": 200, "w": 600, "url": "https://pbs.twimg.com/profile_banners/6253282/1347394302/600x200" }, "1500x500": { "h": 500, "w": 1500, "urls": "https://pbs.twimg.com/profile_banners/6253282/1347394302/1500x500" } } } 
+response_content_type       = "application/json"
+response_location           = ""

--- a/example/flavors/candidate/endpointfoocandidate.flavor
+++ b/example/flavors/candidate/endpointfoocandidate.flavor
@@ -1,0 +1,10 @@
+## ! ~/.rest_shifter/flavors/hello_world.flavor
+method_used                 = "get"
+path                        = "/endpoint/foo"
+request_accept              = ""
+request_content_type        = ""
+response_sleep              = 1
+response_status             = "400"
+response_body               = { "foo" : "candidate", "started_at": "2015-09-18T09:22:52Z", "last_modified_at": "2015-09-18T09:22:52Z" }
+response_content_type       = "application/json"
+response_location           = ""

--- a/example/flavors/candidate/endpointmehcandidate.flavor
+++ b/example/flavors/candidate/endpointmehcandidate.flavor
@@ -1,0 +1,10 @@
+## ! ~/.rest_shifter/flavors/hello_world.flavor
+method_used                 = "get"
+path                        = "/endpoint/meh"
+request_accept              = ""
+request_content_type        = ""
+response_sleep              = 0
+response_status             = "200"
+response_body               = { "hello_meh" : "candidate" }
+response_content_type       = "application/json"
+response_location           = ""

--- a/example/flavors/primary/endpointfooprimary.flavor
+++ b/example/flavors/primary/endpointfooprimary.flavor
@@ -1,0 +1,10 @@
+## ! ~/.rest_shifter/flavors/hello_world.flavor
+method_used                 = "get"
+path                        = "/endpoint/foo"
+request_accept              = ""
+request_content_type        = ""
+response_sleep              = 0
+response_status             = "400"
+response_body               = { "foo" : "primary", "started_at": "2015-09-18T09:22:51Z", "last_modified_at": "2015-09-18T09:22:51Z" }
+response_content_type       = "application/json"
+response_location           = ""

--- a/example/flavors/primary/endpointmehprimary.flavor
+++ b/example/flavors/primary/endpointmehprimary.flavor
@@ -1,0 +1,10 @@
+## ! ~/.rest_shifter/flavors/hello_world.flavor
+method_used                 = "get"
+path                        = "/endpoint/meh"
+request_accept              = ""
+request_content_type        = ""
+response_sleep              = 0
+response_status             = "200"
+response_body               = { "hello_world" : "primary" }
+response_content_type       = "application/json"
+response_location           = ""

--- a/example/flavors/primary/endpointprimary.flavor
+++ b/example/flavors/primary/endpointprimary.flavor
@@ -1,0 +1,10 @@
+## ! ~/.rest_shifter/flavors/hello_world.flavor
+method_used                 = "get"
+path                        = "/endpoint"
+request_accept              = ""
+request_content_type        = ""
+response_sleep              = 0
+response_status             = "200"
+response_body               = { "sizes": { "ipad": { "h": 313, "w": 626, "url": "https://pbs.twimg.com/profile_banners/6253282/1347394302/ipad" }, "ipad_retina": { "h": 626, "w": 1252, "url": "https://pbs.twimg.com/profile_banners/6253282/1347394302/ipad_retina" }, "web": { "h": 260, "w": 520, "url": "https://pbs.twimg.com/profile_banners/6253282/1347394302/web" }, "web_retina": { "h": 520, "w": 1040, "url": "https://pbs.twimg.com/profile_banners/6253282/1347394302/web_retina" }, "mobile": { "h": 160, "w": 320, "url": "https://pbs.twimg.com/profile_banners/6253282/1347394302/mobile" }, "mobile_retina": { "h": 320, "w": 640, "url": "https://pbs.twimg.com/profile_banners/6253282/1347394302/mobile_retina" }, "300x100": { "h": 100, "w": 300, "url": "https://pbs.twimg.com/profile_banners/6253282/1347394302/300x100" }, "600x200": { "h": 200, "w": 600, "url": "https://pbs.twimg.com/profile_banners/6253282/1347394302/600x200" }, "1500x500": { "h": 500, "w": 1500, "url": "https://pbs.twimg.com/profile_banners/6253282/1347394302/1500x500" } } } 
+response_content_type       = "application/json"
+response_location           = ""

--- a/example/flavors/secondary/endpointfoosecondary.flavor
+++ b/example/flavors/secondary/endpointfoosecondary.flavor
@@ -1,0 +1,10 @@
+## ! ~/.rest_shifter/flavors/hello_world.flavor
+method_used                 = "get"
+path                        = "/endpoint/foo"
+request_accept              = ""
+request_content_type        = ""
+response_sleep              = 0
+response_status             = "400"
+response_body               = { "foo" : "secondary", "started_at": "2015-09-18T09:22:53Z", "last_modified_at": "2015-09-18T09:22:53Z" }
+response_content_type       = "application/json"
+response_location           = ""

--- a/example/flavors/secondary/endpointmehsecondary.flavor
+++ b/example/flavors/secondary/endpointmehsecondary.flavor
@@ -1,0 +1,10 @@
+## ! ~/.rest_shifter/flavors/hello_world.flavor
+method_used                 = "get"
+path                        = "/endpoint/meh"
+request_accept              = ""
+request_content_type        = ""
+response_sleep              = 0
+response_status             = "200"
+response_body               = { "hello_bar" : "secondary" }
+response_content_type       = "application/json"
+response_location           = ""

--- a/example/flavors/secondary/endpointsecondary.flavor
+++ b/example/flavors/secondary/endpointsecondary.flavor
@@ -1,0 +1,10 @@
+## ! ~/.rest_shifter/flavors/hello_world.flavor
+method_used                 = "get"
+path                        = "/endpoint"
+request_accept              = ""
+request_content_type        = ""
+response_sleep              = 0
+response_status             = "200"
+response_body               = { "sizes": { "ipad": { "h": 313, "w": 626, "url": "https://pbs.twimg.com/profile_banners/6253282/1347394302/ipad" }, "ipad_retina": { "h": 626, "w": 1252, "url": "https://pbs.twimg.com/profile_banners/6253282/1347394302/ipad_retina" }, "web": { "h": 260, "w": 520, "url": "https://pbs.twimg.com/profile_banners/6253282/1347394302/web" }, "web_retina": { "h": 520, "w": 1040, "url": "https://pbs.twimg.com/profile_banners/6253282/1347394302/web_retina" }, "mobile": { "h": 160, "w": 320, "url": "https://pbs.twimg.com/profile_banners/6253282/1347394302/mobile" }, "mobile_retina": { "h": 320, "w": 640, "url": "https://pbs.twimg.com/profile_banners/6253282/1347394302/mobile_retina" }, "300x100": { "h": 100, "w": 300, "url": "https://pbs.twimg.com/profile_banners/6253282/1347394302/300x100" }, "600x200": { "h": 200, "w": 600, "url": "https://pbs.twimg.com/profile_banners/6253282/1347394302/600x200" }, "1500x500": { "h": 500, "w": 1500, "url": "https://pbs.twimg.com/profile_banners/6253282/1347394302/1500x500" } } } 
+response_content_type       = "application/json"
+response_location           = ""


### PR DESCRIPTION
Adding docker-compose example. 

Three different services running three different endpoints that show part of diffy's features, such as differences in the json objects, response headers and the noise feature. A note was added to the README file in the root directory regarding the example.

Testing is not applicable to that case.

Let me know if you have any question.