### PR TITLE
SSL Support and fix the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: true
 language: scala
 
 scala:
@@ -13,13 +12,14 @@ jdk:
 cache:
   directories:
     - $HOME/.ivy2/cache
-    - $HOME/.sbt/boot
+    - $HOME/.sbt/boot/scala-$TRAVIS_SCALA_VERSION
 
-script:
-  - unset SBT_OPTS
-  - ./sbt ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport
+before_script: unset SBT_OPTS
+
+script: sbt clean coverage test coverageReport
+
+after_script:
   - find $HOME/.sbt -name "*.lock" | xargs rm
   - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
 
 after_success: bash <(curl -s https://codecov.io/bash)
-

--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ Inside the example directory you will find instructions to run a complete exampl
 ## FAQ's
    For safety reasons `POST`, `PUT`, ` DELETE ` are ignored by default . Add ` -allowHttpSideEffects=true ` to your command line arguments to enable these verbs.
 
+## HTTPS
+If you are trying to run Diffy over a HTTPS API, the config required is:
+    ```
+    -service.protocol=https
+    ```
+And in case of the HTTPS port be different than 443:
+    ```
+    -https.port=123
+     ```
 
 ## License
 

--- a/src/main/scala/com/twitter/diffy/DiffyServiceModule.scala
+++ b/src/main/scala/com/twitter/diffy/DiffyServiceModule.scala
@@ -26,7 +26,7 @@ object DiffyServiceModule extends TwitterModule {
     flag[String]("master.secondary", "secondary master serverset where known good code is deployed")
 
   val protocol =
-    flag[String]("service.protocol", "Service protocol, thrift, http or https")
+    flag[String]("service.protocol", "Service protocol: thrift, http or https")
 
   val clientId =
     flag[String]("proxy.clientId", "diffy.proxy", "The clientId to be used by the proxy service to talk to candidate, primary, and master")

--- a/src/main/scala/com/twitter/diffy/DiffyServiceModule.scala
+++ b/src/main/scala/com/twitter/diffy/DiffyServiceModule.scala
@@ -26,7 +26,7 @@ object DiffyServiceModule extends TwitterModule {
     flag[String]("master.secondary", "secondary master serverset where known good code is deployed")
 
   val protocol =
-    flag[String]("service.protocol", "Service protocol, thrift or http")
+    flag[String]("service.protocol", "Service protocol, thrift, http or https")
 
   val clientId =
     flag[String]("proxy.clientId", "diffy.proxy", "The clientId to be used by the proxy service to talk to candidate, primary, and master")

--- a/src/main/scala/com/twitter/diffy/DiffyServiceModule.scala
+++ b/src/main/scala/com/twitter/diffy/DiffyServiceModule.scala
@@ -70,6 +70,9 @@ object DiffyServiceModule extends TwitterModule {
   val skipEmailsWhenNoErrors =
     flag[Boolean]("skipEmailsWhenNoErrors", false, "Do not send emails if there are no critical errors")
 
+  var httpsPort =
+    flag[String]("httpsPort", "443", "Port to be used when using HTTPS as a protocol")
+
   @Provides
   @Singleton
   def settings =
@@ -93,7 +96,8 @@ object DiffyServiceModule extends TwitterModule {
       rootUrl(),
       allowHttpSideEffects(),
       excludeHttpHeadersComparison(),
-      skipEmailsWhenNoErrors()
+      skipEmailsWhenNoErrors(),
+      httpsPort()
     )
 
   @Provides

--- a/src/main/scala/com/twitter/diffy/proxy/DifferenceProxy.scala
+++ b/src/main/scala/com/twitter/diffy/proxy/DifferenceProxy.scala
@@ -21,6 +21,7 @@ object DifferenceProxyModule extends TwitterModule {
     settings.protocol match {
       case "thrift" => ThriftDifferenceProxy(settings, collector, joinedDifferences, analyzer)
       case "http" => SimpleHttpDifferenceProxy(settings, collector, joinedDifferences, analyzer)
+      case "https" => SimpleHttpsDifferenceProxy(settings, collector, joinedDifferences, analyzer)
     }
 }
 

--- a/src/main/scala/com/twitter/diffy/proxy/HttpDifferenceProxy.scala
+++ b/src/main/scala/com/twitter/diffy/proxy/HttpDifferenceProxy.scala
@@ -86,3 +86,28 @@ case class SimpleHttpDifferenceProxy (
       (!settings.allowHttpSideEffects, httpSideEffectsFilter) andThen
       super.proxy
 }
+
+/**
+ * Alternative to SimpleHttpDifferenceProxy allowing HTTPS requests
+ */
+case class SimpleHttpsDifferenceProxy (
+                                       settings: Settings,
+                                       collector: InMemoryDifferenceCollector,
+                                       joinedDifferences: JoinedDifferences,
+                                       analyzer: DifferenceAnalyzer)
+  extends HttpDifferenceProxy
+{
+  import SimpleHttpDifferenceProxy._
+
+  override val servicePort = settings.servicePort
+
+  override val proxy =
+    Filter.identity andThenIf
+      (!settings.allowHttpSideEffects, httpSideEffectsFilter) andThen
+      super.proxy
+
+  override def serviceFactory(serverset: String, label: String) =
+    HttpService(Http.client
+      .withTls(serverset)
+      .newService(serverset+":"+settings.httpsPort, label))
+}

--- a/src/main/scala/com/twitter/diffy/proxy/HttpDifferenceProxy.scala
+++ b/src/main/scala/com/twitter/diffy/proxy/HttpDifferenceProxy.scala
@@ -91,10 +91,10 @@ case class SimpleHttpDifferenceProxy (
  * Alternative to SimpleHttpDifferenceProxy allowing HTTPS requests
  */
 case class SimpleHttpsDifferenceProxy (
-                                       settings: Settings,
-                                       collector: InMemoryDifferenceCollector,
-                                       joinedDifferences: JoinedDifferences,
-                                       analyzer: DifferenceAnalyzer)
+   settings: Settings,
+   collector: InMemoryDifferenceCollector,
+   joinedDifferences: JoinedDifferences,
+   analyzer: DifferenceAnalyzer)
   extends HttpDifferenceProxy
 {
   import SimpleHttpDifferenceProxy._
@@ -107,7 +107,9 @@ case class SimpleHttpsDifferenceProxy (
       super.proxy
 
   override def serviceFactory(serverset: String, label: String) =
-    HttpService(Http.client
+    HttpService(
+      Http.client
       .withTls(serverset)
-      .newService(serverset+":"+settings.httpsPort, label))
+      .newService(serverset+":"+settings.httpsPort, label)
+    )
 }

--- a/src/main/scala/com/twitter/diffy/proxy/Settings.scala
+++ b/src/main/scala/com/twitter/diffy/proxy/Settings.scala
@@ -24,6 +24,7 @@ case class Settings(
   rootUrl: String,
   allowHttpSideEffects: Boolean,
   excludeHttpHeadersComparison: Boolean,
-  skipEmailsWhenNoErrors: Boolean)
+  skipEmailsWhenNoErrors: Boolean,
+  httpsPort: String)
 
 case class Target(path: String)

--- a/src/test/scala/com/twitter/diffy/TestHelper.scala
+++ b/src/test/scala/com/twitter/diffy/TestHelper.scala
@@ -29,7 +29,8 @@ object TestHelper extends MockitoSugar {
     rootUrl = "test",
     allowHttpSideEffects = true,
     excludeHttpHeadersComparison = true,
-    skipEmailsWhenNoErrors = false
+    skipEmailsWhenNoErrors = false,
+    httpsPort = "443"
   )
 
   def makeEmptyJoinedDifferences = {


### PR DESCRIPTION
I am trying to use Diffy, but I am facing the same issue that some people have in #21 
So the idea of this PR is allow Diffy access APIs under HTTPS.

Basically all the user need to do is specify: 
"service.protocol=https" and optionally "https.port=xxx" in case of the https port be different than 443.

I don't have much experience with Scala, so let me know if there's a better way to implement it,
of if any change is required.

As an extra I updated the travis file to fix the build.

Thank you!
