### PR TITLE
Add option to relay the actual service responses

### DIFF
--- a/src/main/scala/com/twitter/diffy/DiffyServiceModule.scala
+++ b/src/main/scala/com/twitter/diffy/DiffyServiceModule.scala
@@ -1,12 +1,14 @@
 package com.twitter.diffy
 
 import com.google.inject.Provides
-import com.twitter.diffy.analysis.{InMemoryDifferenceCollector, NoiseDifferenceCounter, RawDifferenceCounter, InMemoryDifferenceCounter}
-import com.twitter.diffy.proxy.{Target, Settings}
+import com.twitter.diffy.analysis.{InMemoryDifferenceCollector, InMemoryDifferenceCounter, NoiseDifferenceCounter, RawDifferenceCounter}
+import com.twitter.diffy.proxy.{ResponseMode, Settings, Target}
+import com.twitter.diffy.proxy.ResponseMode.EmptyResponse
 import com.twitter.inject.TwitterModule
 import com.twitter.util.TimeConversions._
 import java.net.InetSocketAddress
 import javax.inject.Singleton
+
 import com.twitter.util.Duration
 
 object DiffyServiceModule extends TwitterModule {
@@ -64,6 +66,9 @@ object DiffyServiceModule extends TwitterModule {
   val allowHttpSideEffects =
     flag[Boolean]("allowHttpSideEffects", false, "Ignore POST, PUT, and DELETE requests if set to false")
 
+  val responseMode =
+    flag[ResponseMode]("responseMode", EmptyResponse, "Respond with 'empty' response, or response from 'primary', 'secondary' or 'candidate'")
+
   val excludeHttpHeadersComparison =
     flag[Boolean]("excludeHttpHeadersComparison", false, "Exclude comparison on HTTP headers if set to false")
 
@@ -92,6 +97,7 @@ object DiffyServiceModule extends TwitterModule {
       emailDelay(),
       rootUrl(),
       allowHttpSideEffects(),
+      responseMode(),
       excludeHttpHeadersComparison(),
       skipEmailsWhenNoErrors()
     )

--- a/src/main/scala/com/twitter/diffy/proxy/DifferenceProxy.scala
+++ b/src/main/scala/com/twitter/diffy/proxy/DifferenceProxy.scala
@@ -1,9 +1,11 @@
 package com.twitter.diffy.proxy
 
 import javax.inject.Singleton
+
 import com.google.inject.Provides
 import com.twitter.diffy.analysis._
 import com.twitter.diffy.lifter.Message
+import com.twitter.diffy.proxy.ResponseMode._
 import com.twitter.finagle._
 import com.twitter.inject.TwitterModule
 import com.twitter.logging.Logger
@@ -90,7 +92,15 @@ trait DifferenceProxy {
           }
       }
 
-      NoResponseExceptionFuture
+      def pickRawResponse(pos: Int) =
+        rawResponses flatMap { reps => Future.const(reps(pos)) }
+
+      settings.responseMode match {
+        case EmptyResponse => NoResponseExceptionFuture
+        case FromPrimary   => pickRawResponse(0)
+        case FromCandidate => pickRawResponse(1)
+        case FromSecondary => pickRawResponse(2)
+      }
     }
   }
 

--- a/src/main/scala/com/twitter/diffy/proxy/Settings.scala
+++ b/src/main/scala/com/twitter/diffy/proxy/Settings.scala
@@ -2,6 +2,7 @@ package com.twitter.diffy.proxy
 
 import java.net.InetSocketAddress
 
+import com.twitter.app.Flaggable
 import com.twitter.util.Duration
 
 case class Settings(
@@ -23,7 +24,26 @@ case class Settings(
   emailDelay: Duration,
   rootUrl: String,
   allowHttpSideEffects: Boolean,
+  responseMode: ResponseMode,
   excludeHttpHeadersComparison: Boolean,
   skipEmailsWhenNoErrors: Boolean)
 
 case class Target(path: String)
+
+sealed trait ResponseMode { def name: String }
+object ResponseMode {
+  case object EmptyResponse extends ResponseMode { val name = "empty" }
+  case object FromPrimary   extends ResponseMode { val name = "primary" }
+  case object FromSecondary extends ResponseMode { val name = "secondary" }
+  case object FromCandidate extends ResponseMode { val name = "candidate" }
+
+  implicit val flaggable: Flaggable[ResponseMode] = new Flaggable[ResponseMode] {
+    override def parse(s: String): ResponseMode = s match {
+      case EmptyResponse.name => EmptyResponse
+      case FromPrimary.name   => FromPrimary
+      case FromSecondary.name => FromSecondary
+      case FromCandidate.name => FromCandidate
+    }
+    override def show(m: ResponseMode) = m.name
+  }
+}

--- a/src/test/scala/com/twitter/diffy/TestHelper.scala
+++ b/src/test/scala/com/twitter/diffy/TestHelper.scala
@@ -7,6 +7,7 @@ import com.twitter.util.TimeConversions._
 import org.scalatest.mock.MockitoSugar
 import com.twitter.diffy.analysis._
 import com.twitter.diffy.compare.Difference
+import com.twitter.diffy.proxy.ResponseMode.EmptyResponse
 
 object TestHelper extends MockitoSugar {
   lazy val testSettings = Settings(
@@ -28,6 +29,7 @@ object TestHelper extends MockitoSugar {
     emailDelay = 0.seconds,
     rootUrl = "test",
     allowHttpSideEffects = true,
+    responseMode = EmptyResponse,
     excludeHttpHeadersComparison = true,
     skipEmailsWhenNoErrors = false
   )


### PR DESCRIPTION
Proposed fix for #5 

Adds flag `-responseMode` determining what is returned for calls to the proxy port
Possible values:
- `empty`: respond with empty responses like before (default)
- `primary`, `secondary` or `candidate`: return the responses returned by the designated service

Any comments or suggestions are welcome
