### PR TITLE
Use https instead of http in urls

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers ++= Seq(
   "Twitter's Repository" at "https://maven.twttr.com/",
-  "jgit-repo" at "http://download.eclipse.org/jgit/maven"
+  "jgit-repo" at "https://download.eclipse.org/jgit/maven"
 )
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.13.0")

--- a/sbt
+++ b/sbt
@@ -4,7 +4,7 @@ sbtver=0.13.8
 sbtjar=sbt-launch.jar
 sbtsha128=57d0f04f4b48b11ef7e764f4cea58dee4e806ffd
 
-sbtrepo=http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch
+sbtrepo=https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch
 
 if [ ! -f $sbtjar ]; then
   echo "downloading $sbtjar" 1>&2


### PR DESCRIPTION
This PR changes every instance of an http url to its https version for security reasons.